### PR TITLE
Release: codeforphilly v0.9.0

### DIFF
--- a/.holo/sources/laddr.toml
+++ b/.holo/sources/laddr.toml
@@ -1,7 +1,6 @@
 [holosource]
-url = "../laddr"
+url = "https://github.com/CodeForPhilly/laddr"
 ref = "refs/heads/develop"
 
 [holosource.project]
-holobranch = "emergence-site"
-lens = false
+holobranch = "emergence-skeleton"


### PR DESCRIPTION
- fix: use canonical repo URL in holosource