### PR TITLE
feat(blog): only allow staff to write blog posts

### DIFF
--- a/php-config/Emergence/CMS/BlogRequestHandler.config.d/access.php
+++ b/php-config/Emergence/CMS/BlogRequestHandler.config.d/access.php
@@ -1,0 +1,3 @@
+<?php
+
+Emergence\CMS\BlogRequestHandler::$accountLevelWrite = 'Staff';


### PR DESCRIPTION
Changes the account level required to write blog posts from the default of `'User'` to `'Staff'` so that users must be promoted to staff in order to draft or publish blog posts. This could be refined in the future to allow writing posts in draft status but not publishing