### PR TITLE
content: change leadership openings to a page

### DIFF
--- a/html-templates/includes/site.nav-sitelinks.tpl
+++ b/html-templates/includes/site.nav-sitelinks.tpl
@@ -23,7 +23,7 @@
         <a class="dropdown-item" href="/mission">{_ "Mission"}</a>
         <a class="dropdown-item" href="/pages/code_of_conduct/">{_ "Code of Conduct"}</a>
         <a class="dropdown-item" href="/pages/leadership/">{_ "Organizing Team"}</a>
-        <a class="dropdown-item" href="/pages/leadership-support_team_open_positions/">{_ "Join the Organizing Team"}</a>
+        <a class="dropdown-item" href="/pages/open_leadership_positions/">{_ "Join the Organizing Team"}</a>
         <a class="dropdown-item" href="/contact">{_ "Contact Us"}</a>
     </div>
 </li>


### PR DESCRIPTION
* Changes the top nav link to open leadership positions to refer to a page, rather than a blog post