### PR TITLE
feat(slack): more specific hello message request

### DIFF
--- a/event-handlers/Emergence/Slack/team_join/general-welcome.php
+++ b/event-handlers/Emergence/Slack/team_join/general-welcome.php
@@ -3,6 +3,6 @@
 Emergence\Slack\API::request('chat.postMessage', [
     'post' => [
         'channel' => Emergence\Slack\API::getChannelId('general'),
-        'text' => ":waving: Welcome, <@{$_EVENT['user']['id']}>! What are you hoping to get out of your time with Code for Philly?"
+        'text' => ":waving: Welcome, <@{$_EVENT['user']['id']}>! When you get the chance, please reply to this message in a thread to introduce yourself and mention anything you're hoping to get out of your time with Code for Philly"
     ]
 ]);


### PR DESCRIPTION
Could we get better engagement on the welcoming Slack message by using a more specific ask? Maybe even add on something like "...so a community ambassador can help welcome you"

I'm in no rush to merge this, I just want put it forward as an idea and see if anyone can come up with some iterations