### PR TITLE
fix: create project without slack api

### DIFF
--- a/event-handlers/Laddr/Project/afterRecordSave/slack-announce.php
+++ b/event-handlers/Laddr/Project/afterRecordSave/slack-announce.php
@@ -6,6 +6,10 @@ if (!$Project->isNew) {
     return;
 }
 
+if (!Emergence\Slack\API::isAvailable()) {
+    return;
+}
+
 $attachment = [
     'pretext' => ':construction: A new project has been posted!',
     'title' => $Project->getTitle(),

--- a/event-handlers/Laddr/ProjectUpdate/afterRecordSave/slack-announce.php
+++ b/event-handlers/Laddr/ProjectUpdate/afterRecordSave/slack-announce.php
@@ -8,6 +8,10 @@ if (
     return;
 }
 
+if (!Emergence\Slack\API::isAvailable()) {
+    return;
+}
+
 $attachment = [
     'pretext' => ':tada: New project update!',
     'title' => $ProjectUpdate->getTitle(),


### PR DESCRIPTION
Prevent crash while creating projects on instances without Slack API configured