### PR TITLE
Add blog to top nav about section

### DIFF
--- a/html-templates/designs/site-bootstrap4.tpl
+++ b/html-templates/designs/site-bootstrap4.tpl
@@ -64,6 +64,7 @@
                             <a class="dropdown-item nav-link" href="/pages/leadership-support_team_open_positions/">Join the Organizing Team</a>
                             <a class="dropdown-item nav-link" href="/contact">Contact Us</a>
                             <a class="dropdown-item nav-link" href="/members">Member Directory</a>
+                            <a class="dropdown-item nav-link" href="/blog">Blog</a>			    
                         </div>
                     </li>
                     <li class="nav-item dropdown d-none d-lg-block">

--- a/html-templates/includes/site.nav-sitelinks.tpl
+++ b/html-templates/includes/site.nav-sitelinks.tpl
@@ -25,5 +25,6 @@
         <a class="dropdown-item" href="/pages/leadership/">{_ "Organizing Team"}</a>
         <a class="dropdown-item" href="/pages/open_leadership_positions/">{_ "Join the Organizing Team"}</a>
         <a class="dropdown-item" href="/contact">{_ "Contact Us"}</a>
+        <a class="dropdown-item" href="/blog">{_ "Blog"}</a>        
     </div>
 </li>


### PR DESCRIPTION
This PR adds a link to codeforphilly.org/blog to the top nav, under about